### PR TITLE
Update .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,13 +10,13 @@ UTILS_SECRET=generate_a_new_key
 
 # For production point these at your databases, in development the default
 # should work out of the box.
-DATABASE_URL=postgres://user:pass@localhost:5432/outline
-DATABASE_URL_TEST=postgres://user:pass@localhost:5432/outline-test
+DATABASE_URL=postgres://user:pass@postgres:5432/outline
+DATABASE_URL_TEST=postgres://user:pass@postgres:5432/outline-test
 DATABASE_CONNECTION_POOL_MIN=
 DATABASE_CONNECTION_POOL_MAX=
 # Uncomment this to disable SSL for connecting to Postgres
 # PGSSLMODE=disable
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://redis:6379
 
 # URL should point to the fully qualified, publicly accessible URL. If using a
 # proxy the port in URL and PORT may be different.


### PR DESCRIPTION
Updated .env.sample to point to correct location for docker-compose installation method
There was a misleading url for redis and postgres instances pointing to localohost